### PR TITLE
Enable Argo cluster labels for AWS Bootstrap

### DIFF
--- a/aws/bootstrapping/gitops-eks-addons/main.tf
+++ b/aws/bootstrapping/gitops-eks-addons/main.tf
@@ -49,7 +49,8 @@ locals {
     local.oss_addons,
     { kubernetes_version = local.cluster_version },
     { aws_cluster_name = local.cluster_name },
-    { cloud_provider = "aws" }
+    { cloud_provider = "aws" },
+    var.custom_gitops_labels
   )
 
   addons_metadata = merge(

--- a/aws/bootstrapping/gitops-eks-addons/variables.tf
+++ b/aws/bootstrapping/gitops-eks-addons/variables.tf
@@ -90,6 +90,18 @@ EOT
   default     = null
 }
 
+variable "custom_gitops_labels" {
+  description = <<EOT
+This variable can be used to place additional label information in the ArgoCD in-cluster secret. This information is then also available in the ApplicationSets via metadata.labels. E.g.
+
+custom_gitops_labels = {
+  enable_my_app = "true"
+}
+EOT
+  type        = any
+  default     = null
+}
+
 # external dns
 variable "external_dns_domain_filters" {
   description = "Limit possible target zones by domain suffixes."


### PR DESCRIPTION
I need to set custom app labels for my additional argo applications. This new variable enables this. 